### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -6,6 +6,7 @@ metadata:
   description: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
   annotations:
     github.com/project-slug: Bandwidth/openapi-generator
+    bandwidth.com/languages: Java
     organization: BW
     costCenter: Development - Software Infra
 spec:


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Java`